### PR TITLE
Fixed a little mistake I've noticed

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,13 +9,22 @@ import time
 from devrant.api import dr_api
 from queryctl.dispatcher import dispatch
 
+# We create a lastCheckTime variable, which holds the time when we last checked the notifications...
+lastCheckTime = time.time()
+
 while True:
     print("Running loop")
+    
+    # ...and before we grab the notifications, we store our current lastCheckTime in checkTime and overwrite it with the current time
+    checkTime = int(lastCheckTime)
+    lastCheckTime = time.time()
+    
     notifs = dr_api.getNotifs()
+    # > Between these two function calls is a millisecond where notifications get abandoned! <
     dr_api.clearNotifs()
 
     for notif in notifs["data"]["items"]:
-        if notif["type"] == "comment_mention" and notif["read"] == 0:
+        if notif["type"] == "comment_mention" and notif["created_time"] > checkTime: # Now we only have check if the notification is a new one
             dispatch(notif).start()
-    
+        
     time.sleep(10)


### PR DESCRIPTION
There are some milliseconds between fetching the notifications and clearing the notifications.
So if a user manages to make a request in the exact time between these two actions, the request will be abandoned.
Especially if your internet connection is bad, that's a big issue.

I've fixed it by using `notif["created_time"]` instead of `notif["read"]`.
Just look at my changes.

> THE CODE IS NOT TESTED!
> Please test it before using it in production.

Feel free to ask any questions!